### PR TITLE
Fix iOS release signing scope

### DIFF
--- a/.github/workflows/mobile-release.yml
+++ b/.github/workflows/mobile-release.yml
@@ -273,11 +273,6 @@ jobs:
             -configuration Release \
             -destination 'generic/platform=iOS' \
             -archivePath "$RUNNER_TEMP/$IOS_SCHEME.xcarchive" \
-            DEVELOPMENT_TEAM="$APPLE_TEAM_ID" \
-            CODE_SIGN_STYLE=Manual \
-            CODE_SIGN_IDENTITY="$IOS_DISTRIBUTION_CERTIFICATE_SHA" \
-            PROVISIONING_PROFILE_SPECIFIER="$IOS_PROVISIONING_PROFILE_NAME" \
-            OTHER_CODE_SIGN_FLAGS="--keychain $IOS_KEYCHAIN_PATH" \
             2>&1 | tee .ci/ios-logs/xcode-archive.log
 
       - name: Export signed iOS IPA


### PR DESCRIPTION
## Summary
- stop passing the app provisioning profile as a global xcodebuild override
- keep manual signing scoped to the ISSTrackerIOS app target through its Release xcconfig
- retain explicit CI keychain and distribution-certificate discovery

## Cause
The global provisioning profile was inherited by Firebase and Google Swift Package resource targets, which do not support provisioning profiles.

## Validation
- validated the production workflow as YAML
- ran git diff checks