### PR TITLE
Require Xcode 26 for iOS builds

### DIFF
--- a/.github/workflows/mobile-pr.yml
+++ b/.github/workflows/mobile-pr.yml
@@ -32,6 +32,27 @@ jobs:
           distribution: temurin
           cache: gradle
 
+      - name: Select Xcode 26
+        shell: bash
+        run: |
+          set -euo pipefail
+          for xcode_app in /Applications/Xcode_26*.app /Applications/Xcode-26*.app /Applications/Xcode.app; do
+            [ -d "$xcode_app" ] || continue
+            developer_dir="$xcode_app/Contents/Developer"
+            xcode_version_output="$(DEVELOPER_DIR="$developer_dir" xcodebuild -version 2>&1 || true)"
+            if printf '%s\n' "$xcode_version_output" | grep -q '^Xcode 26'; then
+              export DEVELOPER_DIR="$developer_dir"
+              echo "DEVELOPER_DIR=$developer_dir" >> "$GITHUB_ENV"
+              printf '%s\n' "$xcode_version_output"
+              printf 'iOS SDK %s\n' "$(xcrun --sdk iphoneos --show-sdk-version)"
+              exit 0
+            fi
+          done
+
+          echo "Xcode 26 with the iOS 26 SDK is required but was not found."
+          ls -1 /Applications/Xcode*.app || true
+          exit 1
+
       - name: Install XcodeGen
         run: brew install xcodegen
 

--- a/.github/workflows/mobile-release.yml
+++ b/.github/workflows/mobile-release.yml
@@ -130,6 +130,27 @@ jobs:
           java-version: "17"
           cache: gradle
 
+      - name: Select Xcode 26
+        shell: bash
+        run: |
+          set -euo pipefail
+          for xcode_app in /Applications/Xcode_26*.app /Applications/Xcode-26*.app /Applications/Xcode.app; do
+            [ -d "$xcode_app" ] || continue
+            developer_dir="$xcode_app/Contents/Developer"
+            xcode_version_output="$(DEVELOPER_DIR="$developer_dir" xcodebuild -version 2>&1 || true)"
+            if printf '%s\n' "$xcode_version_output" | grep -q '^Xcode 26'; then
+              export DEVELOPER_DIR="$developer_dir"
+              echo "DEVELOPER_DIR=$developer_dir" >> "$GITHUB_ENV"
+              printf '%s\n' "$xcode_version_output"
+              printf 'iOS SDK %s\n' "$(xcrun --sdk iphoneos --show-sdk-version)"
+              exit 0
+            fi
+          done
+
+          echo "Xcode 26 with the iOS 26 SDK is required but was not found."
+          ls -1 /Applications/Xcode*.app || true
+          exit 1
+
       - name: Install XcodeGen
         run: brew install xcodegen
 

--- a/docs/ios-release-setup.md
+++ b/docs/ios-release-setup.md
@@ -18,7 +18,7 @@ The N2YO credential is intentionally excluded from source control. Local builds 
 
 ## GitHub release delivery
 
-The `Mobile Production Release` workflow archives and signs the iOS Release app, exports an IPA, retains the IPA and dSYMs as workflow artifacts, and uploads the build to App Store Connect for TestFlight processing. It reads version `7.08 (52)` from the same root `version.properties` file used by Android.
+The `Mobile Production Release` workflow explicitly selects Xcode 26 and the iOS 26 SDK, archives and signs the iOS Release app, exports an IPA, retains the IPA and dSYMs as workflow artifacts, and uploads the build to App Store Connect for TestFlight processing. It reads version `7.08 (52)` from the same root `version.properties` file used by Android.
 
 Required repository secrets:
 


### PR DESCRIPTION
## Summary
- explicitly select Xcode 26 and the iOS 26 SDK for PR and production iOS builds
- fail early with installed-Xcode diagnostics if the required toolchain is unavailable
- document the App Store Connect SDK requirement

## Cause
The previous archive and upload succeeded, but App Store Connect rejected the binary because the macOS 15 runner defaulted to Xcode 16.4 and the iOS 18.5 SDK.

## Validation
- validated both workflows as YAML
- ran git diff checks